### PR TITLE
Concatinated description and info in QIF file.

### DIFF
--- a/dkb.py
+++ b/dkb.py
@@ -375,9 +375,10 @@ class DkbConverter(object):
                 continue
             yield 'D%s' % self.format_date(line)
             yield 'T%s' % self.format_value(line)
-            yield 'M%s' % self.format_description(line)
             if line[self.COL_INFO].strip():
-                yield 'M%s' % self.format_info(line)
+                yield 'M%s: %s' % (self.format_description(line), self.format_info(line))
+            else:
+                yield 'M%s' % self.format_description(line)
             category = self.get_category(line)
             if category:
                 yield 'L%s' % category


### PR DESCRIPTION
Gnucash can only handle a single.QIF field denoted with M.
It discards the first line of a multi line M field in the QIF file:

> ^
> D10/05/2015
> T-12.07
> MGROED 2KOEBENHAVN K
> M-90,00 DKK
> ^

In the above case 

> MGROED 2KOEBENHAVN K

 would be missing after importing to Gnucash.
After this pull request these entry look like this:
> ^
> D10/05/2015
> T-12.07
> MGROED 2KOEBENHAVN K: -90,00 DKK
> ^

